### PR TITLE
Add Spring configuration metadata for idempotent modules

### DIFF
--- a/idempotent-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/idempotent-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,43 @@
+{
+  "groups": [
+    {
+      "name": "idempotent",
+      "type": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect",
+      "sourceType": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect"
+    }
+  ],
+  "properties": [
+    {
+      "name": "idempotent.key.header",
+      "type": "java.lang.String",
+      "description": "HTTP Header in request to check for idempotent key. If found, this takes precedence over the annotation key.",
+      "sourceType": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect",
+      "defaultValue": "X-Idempotency-Key"
+    },
+    {
+      "name": "idempotent.inprogress.max.retries",
+      "type": "java.lang.Integer",
+      "description": "Maximum number of retries to wait for a concurrent request that is currently INPROGRESS.",
+      "sourceType": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect",
+      "defaultValue": 5
+    },
+    {
+      "name": "idempotent.inprogress.retry.initial.intervalMillis",
+      "type": "java.lang.Integer",
+      "description": "Initial interval in milliseconds for retrying the status check of an INPROGRESS request.",
+      "sourceType": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect",
+      "defaultValue": 100
+    },
+    {
+      "name": "idempotent.inprogress.retry.multiplier",
+      "type": "java.lang.Integer",
+      "description": "Multiplier for exponential backoff during INPROGRESS status check retries.",
+      "sourceType": "io.github.arun0009.idempotent.core.aspect.IdempotentAspect",
+      "defaultValue": 2
+    }
+  ],
+  "hints": [],
+  "ignored": {
+    "properties": []
+  }
+}

--- a/idempotent-dynamo/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/idempotent-dynamo/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,65 @@
+{
+  "groups": [
+    {
+      "name": "idempotent.dynamodb",
+      "type": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    },
+    {
+      "name": "idempotent.aws",
+      "type": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    }
+  ],
+  "properties": [
+    {
+      "name": "idempotent.aws.region",
+      "type": "java.lang.String",
+      "description": "AWS region for DynamoDB operations.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    },
+    {
+      "name": "idempotent.aws.accessKey",
+      "type": "java.lang.String",
+      "description": "AWS Access Key for authentication.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    },
+    {
+      "name": "idempotent.aws.accessSecret",
+      "type": "java.lang.String",
+      "description": "AWS Access Secret for authentication.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    },
+    {
+      "name": "idempotent.dynamodb.endpoint",
+      "type": "java.lang.String",
+      "description": "Custom DynamoDB endpoint (useful for LocalStack or Testcontainers).",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig"
+    },
+    {
+      "name": "idempotent.dynamodb.use.local",
+      "type": "java.lang.Boolean",
+      "description": "Set to true if using a local DynamoDB instance like LocalStack.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.dynamodb.table.create",
+      "type": "java.lang.Boolean",
+      "description": "Whether the client should attempt to create the DynamoDB table automatically on startup.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.dynamodb.table.name",
+      "type": "java.lang.String",
+      "description": "The name of the DynamoDB table used for storing idempotent data.",
+      "sourceType": "io.github.arun0009.idempotent.dynamo.config.DynamoConfig",
+      "defaultValue": "Idempotent"
+    }
+  ],
+  "hints": [],
+  "ignored": {
+    "properties": []
+  }
+}

--- a/idempotent-redis/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/idempotent-redis/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -1,0 +1,88 @@
+{
+  "groups": [
+    {
+      "name": "idempotent.redis",
+      "type": "io.github.arun0009.idempotent.redis.config.RedisConfig",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    }
+  ],
+  "properties": [
+    {
+      "name": "idempotent.redis.standalone.host",
+      "type": "java.lang.String",
+      "description": "Redis standalone host in 'hostname:port' format.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    },
+    {
+      "name": "idempotent.redis.auth.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable or disable Redis authentication.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.redis.ssl.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable or disable SSL for Redis connections.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.redis.auth.username",
+      "type": "java.lang.String",
+      "description": "Redis username (used only if authentication is enabled).",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    },
+    {
+      "name": "idempotent.redis.auth.password",
+      "type": "java.lang.String",
+      "description": "Redis password (used only if authentication is enabled).",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    },
+    {
+      "name": "idempotent.redis.cluster.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Set to true if using Redis in Cluster mode.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.redis.cluster.hosts",
+      "type": "java.lang.String",
+      "description": "Comma-separated list of cluster hosts in 'host:port' format.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    },
+    {
+      "name": "idempotent.redis.sentinel.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Set to true if using Redis in Sentinel mode.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig",
+      "defaultValue": false
+    },
+    {
+      "name": "idempotent.redis.sentinel.master",
+      "type": "java.lang.String",
+      "description": "Redis Sentinel master name.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    },
+    {
+      "name": "idempotent.redis.sentinel.nodes",
+      "type": "java.lang.String",
+      "description": "Comma-separated list of sentinel nodes in 'host:port' format.",
+      "sourceType": "io.github.arun0009.idempotent.redis.config.RedisConfig"
+    }
+  ],
+  "hints": [
+    {
+      "name": "idempotent.redis.standalone.host",
+      "values": [
+        {
+          "value": "localhost:6379"
+        }
+      ]
+    }
+  ],
+  "ignored": {
+    "properties": []
+  }
+}


### PR DESCRIPTION
This pull request adds Spring configuration metadata for the idempotent modules: core, DynamoDB, and Redis. This ensures better integration with Spring tooling and enhances the development experience. 

I have intentionally chosen to add these metadata files manually rather than integrating the standard Spring Boot annotation processor for the following reasons:
- Avoidance of Major Refactoring: The automated processor works best with `@ConfigurationProperties` beans. Current architecture relies on `@Value` annotations scattered across various components (Aspects, Stores, and Config classes). Transitioning to `@ConfigurationProperties` would require a significant refactor of nested property logic and class hierarchies across multiple modules.

While this manual approach solves the immediate need for IDE support, I acknowledge this is an interim step. We can consider a more "Spring-native" approach in a future major version by:
- Deprecating current `@Value` based properties: Moving toward structured POJOs annotated with `@ConfigurationProperties`.
- Implementing `@AutoConfiguration`: Replacing manual bean definitions with auto-configuration classes to further simplify library integration for end-users.
- Adopting the Processor: Once the refactor to `@ConfigurationProperties` is complete, we can then transition to the automated spring-boot-configuration-processor.

Closes #17 