### PR TITLE
fix: Add annotation processor path spring-boot-configuration-processor

### DIFF
--- a/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/ConfigurationProcessorTest.java
+++ b/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/ConfigurationProcessorTest.java
@@ -1,0 +1,48 @@
+package io.github.arun0009.idempotent.core;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ConfigurationProcessorTest {
+
+    @Test
+    void configurationMetadataIsPresentOnClasspath() {
+        URL url = getClass().getClassLoader().getResource("META-INF/spring-configuration-metadata.json");
+        assertNotNull(url);
+
+        byte[] content = assertDoesNotThrow(() -> Files.readAllBytes(Path.of(url.toURI())));
+        Map<String, Object> root = JsonMapper.shared().readValue(content, new TypeReference<>() {});
+
+        assertNotNull(root);
+        assertTrue(root.containsKey("groups"));
+        assertTrue(root.containsKey("properties"));
+        assertTrue(root.containsKey("hints"));
+        assertTrue(root.containsKey("ignored"));
+
+        @SuppressWarnings("unchecked")
+        Set<String> names = ((List<Map<String, String>>) root.get("properties"))
+                .stream().map(p -> p.get("name")).collect(toSet());
+
+        assertEquals(
+                Set.of(
+                        "idempotent.key.header",
+                        "idempotent.inprogress.max.retries",
+                        "idempotent.inprogress.retry.initial.intervalMillis",
+                        "idempotent.inprogress.retry.multiplier"),
+                names);
+    }
+}

--- a/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/IdempotentControllerTest.java
+++ b/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/IdempotentControllerTest.java
@@ -55,20 +55,25 @@ class IdempotentControllerTest {
     @RepeatedTest(3)
     @Execution(ExecutionMode.CONCURRENT)
     void createAsset(RepetitionInfo repetitionInfo) throws Exception {
-        new IdempotentTest().validateAssetResponse(mockMvc, repetitionInfo.getCurrentRepetition(), "Create", post("/in-memory/assets"));
+        new IdempotentTest()
+                .validateAssetResponse(
+                        mockMvc, repetitionInfo.getCurrentRepetition(), "Create", post("/in-memory/assets"));
     }
 
     @RepeatedTest(3)
     @Execution(ExecutionMode.CONCURRENT)
     void updateAsset(RepetitionInfo repetitionInfo) throws Exception {
-        new IdempotentTest().validateAssetResponse(mockMvc, repetitionInfo.getCurrentRepetition(), "Update", put("/in-memory/assets"));
+        new IdempotentTest()
+                .validateAssetResponse(
+                        mockMvc, repetitionInfo.getCurrentRepetition(), "Update", put("/in-memory/assets"));
     }
 
     @Test
     void updateAssetError() throws Exception {
-        MockHttpServletResponse response = mockMvc.perform(put("/in-memory/assets-error").contentType(MediaType.APPLICATION_JSON)
-                //language=json
-                .content("""
+        MockHttpServletResponse response = mockMvc.perform(put("/in-memory/assets-error")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        // language=json
+                        .content("""
                         {
                              "id": 1111,
                              "type": {
@@ -77,13 +82,15 @@ class IdempotentControllerTest {
                               },
                              "name": "Asset API-1"
                          }
-                        """)).andReturn().getResponse();
+                        """))
+                .andReturn()
+                .getResponse();
 
         assertEquals(404, response.getStatus());
         assertEquals(MediaType.APPLICATION_PROBLEM_JSON_VALUE, response.getContentType());
 
-        Map<String, String> error = assertDoesNotThrow(() -> JsonMapper.shared().readValue(response.getContentAsByteArray(), new TypeReference<>() {
-        }));
+        Map<String, String> error = assertDoesNotThrow(
+                () -> JsonMapper.shared().readValue(response.getContentAsByteArray(), new TypeReference<>() {}));
         assertNotNull(error);
         assertEquals("1111", error.get("id"));
         assertEquals("404", error.get("status"));

--- a/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/NotFoundException.java
+++ b/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/NotFoundException.java
@@ -7,5 +7,4 @@ class NotFoundException extends RuntimeException {
         super(message);
         this.id = id;
     }
-
 }

--- a/idempotent-dynamo/src/test/java/io/github/arun0009/idempotent/dynamo/DynamoConfigurationProcessorTest.java
+++ b/idempotent-dynamo/src/test/java/io/github/arun0009/idempotent/dynamo/DynamoConfigurationProcessorTest.java
@@ -1,0 +1,51 @@
+package io.github.arun0009.idempotent.dynamo;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DynamoConfigurationProcessorTest {
+
+    @Test
+    void configurationMetadataIsPresentOnClasspath() {
+        URL url = getClass().getClassLoader().getResource("META-INF/spring-configuration-metadata.json");
+        assertNotNull(url);
+
+        byte[] content = assertDoesNotThrow(() -> Files.readAllBytes(Path.of(url.toURI())));
+        Map<String, Object> root = JsonMapper.shared().readValue(content, new TypeReference<>() {});
+
+        assertNotNull(root);
+        assertTrue(root.containsKey("groups"));
+        assertTrue(root.containsKey("properties"));
+        assertTrue(root.containsKey("hints"));
+        assertTrue(root.containsKey("ignored"));
+
+        @SuppressWarnings("unchecked")
+        Set<String> names = ((List<Map<String, String>>) root.get("properties"))
+                .stream().map(p -> p.get("name")).collect(toSet());
+
+        assertEquals(
+                Set.of(
+                        "idempotent.aws.region",
+                        "idempotent.aws.accessKey",
+                        "idempotent.aws.accessSecret",
+                        "idempotent.dynamodb.endpoint",
+                        "idempotent.dynamodb.use.local",
+                        "idempotent.dynamodb.table.create",
+                        "idempotent.dynamodb.table.name"),
+                names);
+    }
+}

--- a/idempotent-nats/pom.xml
+++ b/idempotent-nats/pom.xml
@@ -30,15 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-configuration-processor</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/idempotent-nats/src/test/java/io/github/arun0009/idempotent/nats/NatsConfigurationProcessorTest.java
+++ b/idempotent-nats/src/test/java/io/github/arun0009/idempotent/nats/NatsConfigurationProcessorTest.java
@@ -1,0 +1,55 @@
+package io.github.arun0009.idempotent.nats;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NatsConfigurationProcessorTest {
+
+    @Test
+    void configurationMetadataIsPresentOnClasspath() {
+        URL url = getClass().getClassLoader().getResource("META-INF/spring-configuration-metadata.json");
+        assertNotNull(url);
+
+        byte[] content = assertDoesNotThrow(() -> Files.readAllBytes(Path.of(url.toURI())));
+        Map<String, Object> root = JsonMapper.shared().readValue(content, new TypeReference<>() {});
+
+        assertNotNull(root);
+        assertTrue(root.containsKey("groups"));
+        assertTrue(root.containsKey("properties"));
+        assertTrue(root.containsKey("hints"));
+        assertTrue(root.containsKey("ignored"));
+
+        @SuppressWarnings("unchecked")
+        Set<String> names = ((List<Map<String, String>>) root.get("properties"))
+                .stream().map(p -> p.get("name")).collect(toSet());
+
+        assertEquals(
+                Set.of(
+                        "idempotent.nats.auth.password",
+                        "idempotent.nats.auth.token",
+                        "idempotent.nats.auth.type",
+                        "idempotent.nats.auth.username",
+                        "idempotent.nats.connection-timeout",
+                        "idempotent.nats.enable",
+                        "idempotent.nats.max-reconnects",
+                        "idempotent.nats.ping-interval",
+                        "idempotent.nats.reconnect-wait",
+                        "idempotent.nats.servers",
+                        "idempotent.nats.verbose"),
+                names);
+    }
+}

--- a/idempotent-redis/src/test/java/io/github/arun0009/idempotent/redis/RedisConfigurationProcessorTest.java
+++ b/idempotent-redis/src/test/java/io/github/arun0009/idempotent/redis/RedisConfigurationProcessorTest.java
@@ -1,0 +1,59 @@
+package io.github.arun0009.idempotent.redis;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RedisConfigurationProcessorTest {
+
+    @Test
+    void configurationMetadataIsPresentOnClasspath() {
+        URL url = getClass().getClassLoader().getResource("META-INF/spring-configuration-metadata.json");
+        assertNotNull(url);
+
+        byte[] content = assertDoesNotThrow(() -> Files.readAllBytes(Path.of(url.toURI())));
+        Map<String, Object> root = JsonMapper.shared().readValue(content, new TypeReference<>() {});
+
+        assertNotNull(root);
+        assertTrue(root.containsKey("groups"));
+        assertTrue(root.containsKey("properties"));
+        assertTrue(root.containsKey("hints"));
+        assertTrue(root.containsKey("ignored"));
+
+        @SuppressWarnings("unchecked")
+        Set<String> groupNames = ((List<Map<String, String>>) root.get("groups"))
+                .stream().map(p -> p.get("name")).collect(toSet());
+        assertEquals(Set.of("idempotent.redis"), groupNames);
+
+        @SuppressWarnings("unchecked")
+        Set<String> propertyNames = ((List<Map<String, String>>) root.get("properties"))
+                .stream().map(p -> p.get("name")).collect(toSet());
+
+        assertEquals(
+                Set.of(
+                        "idempotent.redis.standalone.host",
+                        "idempotent.redis.auth.enabled",
+                        "idempotent.redis.ssl.enabled",
+                        "idempotent.redis.auth.username",
+                        "idempotent.redis.auth.password",
+                        "idempotent.redis.cluster.enabled",
+                        "idempotent.redis.cluster.hosts",
+                        "idempotent.redis.sentinel.enabled",
+                        "idempotent.redis.sentinel.master",
+                        "idempotent.redis.sentinel.nodes"),
+                propertyNames);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-configuration-processor</artifactId>
+                <scope>provided</scope>
+                <optional>true</optional>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -129,6 +135,13 @@
                         <compilerArgs>
                             <arg>-parameters</arg>
                         </compilerArgs>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.springframework.boot</groupId>
+                                <artifactId>spring-boot-configuration-processor</artifactId>
+                                <version>${spring-boot.version}</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                 </plugin>
             </plugins>


### PR DESCRIPTION
This PR fixes the generation of the metadata file during compilation by configuring the annotation processor path, and also adds the same test to the other modules