### PR TITLE
upgrade nullaway ver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
-        <nullaway.version>0.13.1</nullaway.version>
+        <nullaway.version>0.13.2</nullaway.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spotless.version>3.4.0</spotless.version>


### PR DESCRIPTION
Updating nullaway to 0.13.2 as it was incompatible with error prone and was causing compilation errors. More details at https://github.com/uber/NullAway/issues/1511.