### PR TITLE
rds opt-in table creation at startup (never/embedded/always)

### DIFF
--- a/idempotent-rds/README.md
+++ b/idempotent-rds/README.md
@@ -43,10 +43,14 @@ CREATE TABLE idempotent (
 	PRIMARY KEY (key_id, process_name)
 );
 
-CREATE INDEX idx_expires_at ON idempotent (expires_at);
+CREATE INDEX idx_idempotent_expires_at ON idempotent (expires_at);
 ```
 
+On MySQL/MariaDB use `MEDIUMTEXT` for `response` (`TEXT` is 64KB).
+
 `expires_at` is epoch **milliseconds**. The composite primary key serves point lookups; the `expires_at` index serves the cleanup task. Unrecognized dialects fall back to a generic implementation with a startup warning.
+
+To create the table at startup instead, set `idempotent.rds.initialize-schema` to `embedded` (H2 only) or `always`. Default is `never`. Runs after Flyway/Liquibase.
 
 ## Under the hood
 
@@ -64,7 +68,8 @@ Shared retry / header / serialization properties: [idempotent-core – Configura
 | Property | Default | Description |
 |----------|---------|-------------|
 | `idempotent.rds.enabled` | `true` | Disable auto-configuration |
-| `idempotent.rds.table-name` | `idempotent` | Table name |
+| `idempotent.rds.table-name` | `idempotent` | Table name (`audit.idempotent` is ok) |
+| `idempotent.rds.initialize-schema` | `never` | Create the table at startup: `never`, `embedded` (H2), `always` |
 | `idempotent.rds.cleanup.enabled` | `true` | Scheduled expiry sweep |
 | `idempotent.rds.cleanup.fixed-delay` | `PT1M` | Time between cleanup runs (`60s`, `PT1M`, …) |
 | `idempotent.rds.cleanup.batch-size` | `1000` | Rows per delete batch (avoids long locks) |

--- a/idempotent-rds/pom.xml
+++ b/idempotent-rds/pom.xml
@@ -32,6 +32,16 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-sql</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-jdbc</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsAutoConfiguration.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsAutoConfiguration.java
@@ -8,11 +8,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
-import org.springframework.util.Assert;
 
 import javax.sql.DataSource;
 
@@ -21,7 +23,12 @@ import javax.sql.DataSource;
             "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration",
             "org.springframework.boot.jdbc.autoconfigure.JdbcTemplateAutoConfiguration"
         })
-@ConditionalOnClass({DataSource.class, JdbcTemplate.class})
+@ConditionalOnClass({
+    DataSource.class,
+    JdbcTemplate.class,
+    DatabaseInitializationMode.class,
+    EmbeddedDatabaseConnection.class
+})
 @ConditionalOnBean(DataSource.class)
 @ConditionalOnProperty(prefix = "idempotent.rds", name = "enabled", matchIfMissing = true)
 @EnableConfigurationProperties(RdsIdempotentProperties.class)
@@ -29,12 +36,19 @@ public class RdsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
+    @DependsOnDatabaseInitialization
+    public RdsSchemaInitializer rdsSchemaInitializer(
+            DataSource dataSource, JdbcTemplate jdbcTemplate, RdsIdempotentProperties properties) {
+        return new RdsSchemaInitializer(
+                dataSource, jdbcTemplate, properties.tableName(), properties.initializeSchema());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
     public IdempotentStore idempotentStore(
             JdbcTemplate jdbcTemplate,
             RdsIdempotentProperties properties,
             IdempotentPayloadCodec idempotentPayloadCodec) {
-        Assert.hasText(properties.tableName(), "idempotent.rds.table-name must not be blank");
-
         return new RdsIdempotentStore(jdbcTemplate, properties.tableName(), idempotentPayloadCodec);
     }
 

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsIdempotentProperties.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsIdempotentProperties.java
@@ -2,21 +2,28 @@ package io.github.arun0009.idempotent.rds;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 
 import java.time.Duration;
 
 /**
  * Configuration properties for RDS-based idempotency implementation.
  *
- * @param enabled   whether the RDS auto-configuration is active
- * @param tableName the name of the database table used to store idempotent keys
- * @param cleanup   configuration for the cleanup task that removes expired records
+ * @param enabled          whether the RDS auto-configuration is active
+ * @param tableName        the name of the database table used to store idempotent keys
+ * @param initializeSchema when to create the table at startup
+ * @param cleanup          configuration for the cleanup task that removes expired records
  */
 @ConfigurationProperties(prefix = "idempotent.rds")
 public record RdsIdempotentProperties(
         @DefaultValue("true") boolean enabled,
         @DefaultValue("idempotent") String tableName,
+        @DefaultValue("never") DatabaseInitializationMode initializeSchema,
         @DefaultValue Cleanup cleanup) {
+
+    public RdsIdempotentProperties {
+        RdsSchemaStatements.validateIdentifier(tableName);
+    }
 
     /**
      * Configuration for the cleanup task that removes expired idempotent records.

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
@@ -1,0 +1,75 @@
+package io.github.arun0009.idempotent.rds;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+
+/** Creates the idempotent table when {@code initialize-schema} is enabled. */
+public class RdsSchemaInitializer implements InitializingBean {
+
+    private static final Logger log = LoggerFactory.getLogger(RdsSchemaInitializer.class);
+
+    private final DataSource dataSource;
+    private final JdbcTemplate jdbcTemplate;
+    private final String tableName;
+    private final DatabaseInitializationMode mode;
+
+    public RdsSchemaInitializer(
+            DataSource dataSource, JdbcTemplate jdbcTemplate, String tableName, DatabaseInitializationMode mode) {
+        this.dataSource = dataSource;
+        this.jdbcTemplate = jdbcTemplate;
+        this.tableName = tableName;
+        this.mode = mode;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        if (!shouldCreate()) {
+            return;
+        }
+        var dialect = RdsDialect.detect(jdbcTemplate);
+        if (dialect == RdsDialect.GENERIC) {
+            log.warn("Not creating idempotent table '{}': unrecognized database", tableName);
+            return;
+        }
+        create(dialect);
+    }
+
+    private boolean shouldCreate() {
+        return switch (mode) {
+            case NEVER -> false;
+            case EMBEDDED -> EmbeddedDatabaseConnection.isEmbedded(dataSource);
+            case ALWAYS -> true;
+        };
+    }
+
+    private void create(RdsDialect dialect) {
+        for (var statement : RdsSchemaStatements.ddl(dialect, tableName)) {
+            try {
+                jdbcTemplate.execute(statement);
+            } catch (DuplicateKeyException e) {
+                // Concurrent CREATE TABLE IF NOT EXISTS on Postgres hits a catalog unique index.
+                if (!tableExists()) {
+                    throw e;
+                }
+                log.debug("Idempotent table '{}' already exists", tableName, e);
+            }
+        }
+    }
+
+    private boolean tableExists() {
+        try {
+            jdbcTemplate.execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(tableName));
+            return true;
+        } catch (BadSqlGrammarException e) {
+            return false;
+        }
+    }
+}

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
@@ -1,0 +1,50 @@
+package io.github.arun0009.idempotent.rds;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+final class RdsSchemaStatements {
+
+    // Unquoted identifier, optionally catalog- or schema-qualified.
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*){0,2}");
+
+    private RdsSchemaStatements() {}
+
+    static List<String> ddl(RdsDialect dialect, String tableName) {
+        var indexName = "idx_%s_expires_at".formatted(tableName.replace('.', '_'));
+        return switch (dialect) {
+            // MySQL has no portable CREATE INDEX IF NOT EXISTS; TEXT is 64KB.
+            case MYSQL -> List.of("""
+                    CREATE TABLE IF NOT EXISTS %s (
+                        key_id VARCHAR(255) NOT NULL,
+                        process_name VARCHAR(255) NOT NULL,
+                        status VARCHAR(50) NOT NULL,
+                        expires_at BIGINT NOT NULL,
+                        response MEDIUMTEXT,
+                        PRIMARY KEY (key_id, process_name),
+                        KEY %s (expires_at)
+                    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4""".formatted(tableName, indexName));
+            case POSTGRES, H2 ->
+                List.of(
+                        """
+                        CREATE TABLE IF NOT EXISTS %s (
+                            key_id VARCHAR(255) NOT NULL,
+                            process_name VARCHAR(255) NOT NULL,
+                            status VARCHAR(50) NOT NULL,
+                            expires_at BIGINT NOT NULL,
+                            response TEXT,
+                            PRIMARY KEY (key_id, process_name)
+                        )""".formatted(tableName),
+                        "CREATE INDEX IF NOT EXISTS %s ON %s (expires_at)".formatted(indexName, tableName));
+            case GENERIC -> throw new IllegalArgumentException("No DDL for unrecognized database: " + tableName);
+        };
+    }
+
+    static String validateIdentifier(String identifier) {
+        if (!IDENTIFIER.matcher(identifier).matches()) {
+            throw new IllegalArgumentException(
+                    "idempotent.rds.table-name is not a valid SQL identifier: " + identifier);
+        }
+        return identifier;
+    }
+}

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsAutoConfigurationTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsAutoConfigurationTest.java
@@ -1,0 +1,96 @@
+package io.github.arun0009.idempotent.rds;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.github.arun0009.idempotent.core.serialization.IdempotentPayloadCodec;
+import io.github.arun0009.idempotent.core.serialization.JacksonIdempotentPayloadCodec;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import tools.jackson.databind.json.JsonMapper;
+
+import javax.sql.DataSource;
+import java.util.Objects;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RdsAutoConfigurationTest {
+
+    private HikariDataSource dataSource;
+    private ApplicationContextRunner runner;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:h2:mem:autoconfig-%s".formatted(UUID.randomUUID()));
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        runner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(RdsAutoConfiguration.class))
+                .withBean(DataSource.class, () -> dataSource)
+                .withBean(JdbcTemplate.class, () -> new JdbcTemplate(dataSource))
+                .withBean(
+                        IdempotentPayloadCodec.class,
+                        () -> new JacksonIdempotentPayloadCodec(
+                                JsonMapper.builder().build()));
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataSource.close();
+    }
+
+    @Test
+    void defaultDoesNotCreateTable() {
+        runner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context.getBean(RdsIdempotentProperties.class).initializeSchema())
+                    .isEqualTo(DatabaseInitializationMode.NEVER);
+            assertThatThrownBy(() -> rowCount(context, "idempotent")).isInstanceOf(BadSqlGrammarException.class);
+        });
+    }
+
+    @Test
+    void embeddedCreatesTableOnH2() {
+        runner.withPropertyValues("idempotent.rds.initialize-schema=embedded").run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(rowCount(context, "idempotent")).isZero();
+        });
+    }
+
+    @Test
+    void alwaysHonorsCustomTableName() {
+        runner.withPropertyValues("idempotent.rds.initialize-schema=always", "idempotent.rds.table-name=my_keys")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(rowCount(context, "my_keys")).isZero();
+                });
+    }
+
+    @Test
+    void rejectsInvalidTableName() {
+        runner.withPropertyValues("idempotent.rds.table-name=idempotent;DROP TABLE users")
+                .run(context -> assertThat(startupFailure(context))
+                        .rootCause()
+                        .isInstanceOf(IllegalArgumentException.class)
+                        .hasMessageContaining("is not a valid SQL identifier"));
+    }
+
+    private static Throwable startupFailure(AssertableApplicationContext context) {
+        return Objects.requireNonNull(context.getStartupFailure(), "expected the context to fail to start");
+    }
+
+    private static int rowCount(AssertableApplicationContext context, String tableName) {
+        var count = context.getBean(JdbcTemplate.class)
+                .queryForObject("SELECT COUNT(*) FROM %s".formatted(tableName), Integer.class);
+        return Objects.requireNonNull(count, "COUNT(*) never returns null");
+    }
+}

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreH2Test.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreH2Test.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
@@ -64,6 +65,12 @@ class RdsIdempotentStoreH2Test {
         }
 
         @Bean
+        public RdsSchemaInitializer rdsSchemaInitializer(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+            return new RdsSchemaInitializer(
+                    dataSource, jdbcTemplate, "idempotent", DatabaseInitializationMode.EMBEDDED);
+        }
+
+        @Bean
         public IdempotentStore idempotentStore(JdbcTemplate jdbcTemplate) {
             return new RdsIdempotentStore(
                     jdbcTemplate,
@@ -81,19 +88,6 @@ class RdsIdempotentStoreH2Test {
 
     @BeforeEach
     void setUp() {
-        // Create table for H2
-        jdbcTemplate.update("""
-                CREATE TABLE IF NOT EXISTS idempotent (
-                    key_id VARCHAR(255) NOT NULL,
-                    process_name VARCHAR(255) NOT NULL,
-                    status VARCHAR(50),
-                    expires_at BIGINT,
-                    response TEXT,
-                    PRIMARY KEY (key_id, process_name)
-                )
-                """);
-
-        jdbcTemplate.update("CREATE INDEX IF NOT EXISTS idx_expires_at ON idempotent(expires_at)");
         jdbcTemplate.update("DELETE FROM idempotent");
     }
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreMySQLTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreMySQLTest.java
@@ -39,26 +39,6 @@ class RdsIdempotentStoreMySQLTest {
 
     @BeforeEach
     void setUp() {
-        // Create the table for MySQL
-        jdbcTemplate.update("""
-                CREATE TABLE IF NOT EXISTS idempotent (
-                    key_id VARCHAR(255) NOT NULL,
-                    process_name VARCHAR(255) NOT NULL,
-                    status VARCHAR(50),
-                    expires_at BIGINT,
-                    response TEXT,
-                    PRIMARY KEY (key_id, process_name)
-                )
-                """);
-
-        // MySQL doesn't support CREATE INDEX IF NOT EXISTS, so we check first
-        try {
-            jdbcTemplate.update("CREATE INDEX idx_expires_at ON idempotent(expires_at)");
-        } catch (Exception e) {
-            // Index already exists, ignore
-        }
-
-        // Clean up the database before each test
         jdbcTemplate.update("DELETE FROM idempotent");
     }
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStorePostgreSQLTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStorePostgreSQLTest.java
@@ -39,21 +39,6 @@ class RdsIdempotentStorePostgreSQLTest {
 
     @BeforeEach
     void setUp() {
-        // Create the table for PostgreSQL
-        jdbcTemplate.update("""
-                    CREATE TABLE IF NOT EXISTS idempotent (
-                        key_id VARCHAR(255) NOT NULL,
-                        process_name VARCHAR(255) NOT NULL,
-                        status VARCHAR(50),
-                        expires_at BIGINT,
-                        response TEXT,
-                        PRIMARY KEY (key_id, process_name)
-                    )
-                """);
-
-        jdbcTemplate.update("CREATE INDEX IF NOT EXISTS idx_expires_at ON idempotent(expires_at)");
-
-        // Clean up the database before each test
         jdbcTemplate.update("DELETE FROM idempotent");
     }
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsMySQLTestConfig.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsMySQLTestConfig.java
@@ -3,6 +3,7 @@ package io.github.arun0009.idempotent.rds;
 import com.zaxxer.hikari.HikariDataSource;
 import io.github.arun0009.idempotent.core.persistence.IdempotentStore;
 import io.github.arun0009.idempotent.core.serialization.JacksonIdempotentPayloadCodec;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -44,6 +45,11 @@ class RdsMySQLTestConfig {
     @Bean
     JdbcTemplate jdbcTemplate(DataSource dataSource) {
         return new JdbcTemplate(dataSource);
+    }
+
+    @Bean
+    RdsSchemaInitializer rdsSchemaInitializer(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+        return new RdsSchemaInitializer(dataSource, jdbcTemplate, "idempotent", DatabaseInitializationMode.ALWAYS);
     }
 
     @Bean

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsPostgreSQLTestConfig.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsPostgreSQLTestConfig.java
@@ -3,6 +3,7 @@ package io.github.arun0009.idempotent.rds;
 import com.zaxxer.hikari.HikariDataSource;
 import io.github.arun0009.idempotent.core.persistence.IdempotentStore;
 import io.github.arun0009.idempotent.core.serialization.JacksonIdempotentPayloadCodec;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -44,6 +45,11 @@ class RdsPostgreSQLTestConfig {
     @Bean
     JdbcTemplate jdbcTemplate(DataSource dataSource) {
         return new JdbcTemplate(dataSource);
+    }
+
+    @Bean
+    RdsSchemaInitializer rdsSchemaInitializer(DataSource dataSource, JdbcTemplate jdbcTemplate) {
+        return new RdsSchemaInitializer(dataSource, jdbcTemplate, "idempotent", DatabaseInitializationMode.ALWAYS);
     }
 
     @Bean

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializerTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializerTest.java
@@ -1,0 +1,155 @@
+package io.github.arun0009.idempotent.rds;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.ConnectionCallback;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.never;
+
+class RdsSchemaInitializerTest {
+
+    private HikariDataSource dataSource;
+    private JdbcTemplate jdbcTemplate;
+
+    @BeforeEach
+    void setUp() {
+        dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:h2:mem:schema-init-%s".formatted(UUID.randomUUID()));
+        dataSource.setDriverClassName("org.h2.Driver");
+        dataSource.setUsername("sa");
+        dataSource.setPassword("");
+        jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataSource.close();
+    }
+
+    @Test
+    void createsTableWhenEmbedded() {
+        initializer("idempotent", DatabaseInitializationMode.EMBEDDED).afterPropertiesSet();
+
+        assertEquals(0, countRows("idempotent"));
+    }
+
+    @Test
+    void createsTableWhenAlways() {
+        initializer("my_keys", DatabaseInitializationMode.ALWAYS).afterPropertiesSet();
+
+        assertEquals(0, countRows("my_keys"));
+    }
+
+    @Test
+    void createsSchemaQualifiedTable() {
+        jdbcTemplate.execute("CREATE SCHEMA IF NOT EXISTS audit");
+
+        initializer("audit.idempotent", DatabaseInitializationMode.EMBEDDED).afterPropertiesSet();
+
+        assertEquals(0, countRows("audit.idempotent"));
+    }
+
+    @Test
+    void isIdempotentIfTableExists() {
+        var initializer = initializer("idempotent", DatabaseInitializationMode.ALWAYS);
+        initializer.afterPropertiesSet();
+        jdbcTemplate.update(
+                "INSERT INTO idempotent (key_id, process_name, status, expires_at) VALUES ('k', 'p', 'COMPLETED', 1)");
+
+        assertDoesNotThrow(initializer::afterPropertiesSet);
+        assertEquals(1, countRows("idempotent"));
+    }
+
+    @Test
+    void doesNothingWhenNever() {
+        initializer("idempotent", DatabaseInitializationMode.NEVER).afterPropertiesSet();
+
+        assertThrows(BadSqlGrammarException.class, () -> countRows("idempotent"));
+    }
+
+    @Test
+    void embeddedSkipsNonEmbeddedDataSource() throws SQLException {
+        var postgres = Mockito.mock(JdbcTemplate.class);
+        var remote = Mockito.mock(DataSource.class);
+        Mockito.doThrow(new SQLException("not an embedded database"))
+                .when(remote)
+                .getConnection();
+
+        new RdsSchemaInitializer(remote, postgres, "idempotent", DatabaseInitializationMode.EMBEDDED)
+                .afterPropertiesSet();
+
+        Mockito.verify(postgres, never()).execute(anyString());
+    }
+
+    @Test
+    void skipsUnrecognizedDialect() {
+        var unrecognized = Mockito.mock(JdbcTemplate.class);
+        Mockito.doReturn(RdsDialect.GENERIC).when(unrecognized).execute(any(ConnectionCallback.class));
+
+        new RdsSchemaInitializer(dataSource, unrecognized, "idempotent", DatabaseInitializationMode.ALWAYS)
+                .afterPropertiesSet();
+
+        Mockito.verify(unrecognized, never()).execute(startsWith("CREATE"));
+    }
+
+    @Test
+    void ignoresCreateRaceIfTableExists() {
+        var initializer = new RdsSchemaInitializer(
+                dataSource, racingOnCreateTable(true), "idempotent", DatabaseInitializationMode.ALWAYS);
+
+        assertDoesNotThrow(initializer::afterPropertiesSet);
+        assertEquals(0, countRows("idempotent"));
+    }
+
+    @Test
+    void rethrowsIfTableMissingAfterRace() {
+        var initializer = new RdsSchemaInitializer(
+                dataSource, racingOnCreateTable(false), "idempotent", DatabaseInitializationMode.ALWAYS);
+
+        assertThrows(DuplicateKeyException.class, initializer::afterPropertiesSet);
+    }
+
+    private JdbcTemplate racingOnCreateTable(boolean winnerCreatesTheTable) {
+        var racing = Mockito.spy(jdbcTemplate);
+        Mockito.doAnswer(invocation -> {
+                    String sql = invocation.getArgument(0);
+                    if (!sql.startsWith("CREATE TABLE")) {
+                        return invocation.callRealMethod();
+                    }
+                    if (winnerCreatesTheTable) {
+                        jdbcTemplate.execute(sql);
+                    }
+                    throw new DuplicateKeyException(
+                            "duplicate key value violates unique constraint \"pg_type_typname_nsp_index\"");
+                })
+                .when(racing)
+                .execute(anyString());
+        return racing;
+    }
+
+    private RdsSchemaInitializer initializer(String tableName, DatabaseInitializationMode mode) {
+        return new RdsSchemaInitializer(dataSource, jdbcTemplate, tableName, mode);
+    }
+
+    private int countRows(String tableName) {
+        var count = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM %s".formatted(tableName), Integer.class);
+        return count == null ? -1 : count;
+    }
+}

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
@@ -1,0 +1,83 @@
+package io.github.arun0009.idempotent.rds;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RdsSchemaStatementsTest {
+
+    @Test
+    void rendersMySql() {
+        assertEquals(List.of("""
+                        CREATE TABLE IF NOT EXISTS idempotent (
+                            key_id VARCHAR(255) NOT NULL,
+                            process_name VARCHAR(255) NOT NULL,
+                            status VARCHAR(50) NOT NULL,
+                            expires_at BIGINT NOT NULL,
+                            response MEDIUMTEXT,
+                            PRIMARY KEY (key_id, process_name),
+                            KEY idx_idempotent_expires_at (expires_at)
+                        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"""), RdsSchemaStatements.ddl(RdsDialect.MYSQL, "idempotent"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = RdsDialect.class,
+            names = {"POSTGRES", "H2"})
+    void rendersPostgresAndH2(RdsDialect dialect) {
+        assertEquals(
+                List.of("""
+                        CREATE TABLE IF NOT EXISTS idempotent (
+                            key_id VARCHAR(255) NOT NULL,
+                            process_name VARCHAR(255) NOT NULL,
+                            status VARCHAR(50) NOT NULL,
+                            expires_at BIGINT NOT NULL,
+                            response TEXT,
+                            PRIMARY KEY (key_id, process_name)
+                        )""", "CREATE INDEX IF NOT EXISTS idx_idempotent_expires_at ON idempotent (expires_at)"),
+                RdsSchemaStatements.ddl(dialect, "idempotent"));
+    }
+
+    @Test
+    void rejectsGeneric() {
+        assertThrows(IllegalArgumentException.class, () -> RdsSchemaStatements.ddl(RdsDialect.GENERIC, "idempotent"));
+    }
+
+    @Test
+    void indexNameFromQualifiedTable() {
+        var statements = RdsSchemaStatements.ddl(RdsDialect.POSTGRES, "audit.idempotent");
+
+        assertEquals(
+                "CREATE INDEX IF NOT EXISTS idx_audit_idempotent_expires_at ON audit.idempotent (expires_at)",
+                statements.get(1));
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+            strings = {
+                "idempotent;DROP TABLE users",
+                "idem potent",
+                "1idempotent",
+                "idem-potent",
+                "",
+                "audit.",
+                ".idempotent",
+                "audit..idempotent",
+                "a.b.c.d"
+            })
+    void rejectsInvalidTableName(String tableName) {
+        assertThrows(IllegalArgumentException.class, () -> RdsSchemaStatements.validateIdentifier(tableName));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"idempotent_keys_2", "audit.idempotent", "catalog.schema.table"})
+    void acceptsValidTableName(String tableName) {
+        assertEquals(tableName, RdsSchemaStatements.validateIdentifier(tableName));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `idempotent.rds.initialize-schema` (`never` / `embedded` / `always`). Default is `never`.
- `embedded` is the shared-config setting: H2 is created, Postgres/MySQL are left alone.
- No Liquibase/Flyway in the library — this table lives in the app's database. Creation runs after the app's own migrations via `DependsOnDatabaseInitialization`.
- Table names are validated as plain SQL identifiers (schema-qualified names are fine).

Closes #166.
