### PR TITLE
add README for idempotent-micrometer module

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ All four share the same serialization, expiry, and state machine — swap backen
 
 ## Metrics
 
-Optional Micrometer integration in the `idempotent-micrometer` module:
+Optional Micrometer integration in **[idempotent-micrometer](idempotent-micrometer/README.md)**:
 
 | Meter | Type | Tags |
 |-------|------|------|

--- a/idempotent-core/README.md
+++ b/idempotent-core/README.md
@@ -78,6 +78,10 @@ Other overloads exist — `execute(key, supplier, ttl)`, `execute(key, processNa
 
 `IdempotentException` and `IdempotentWaitExhaustedException` are library-only. Your domain exceptions stay yours.
 
+## Metrics
+
+Optional. Add **[idempotent-micrometer](../idempotent-micrometer/README.md)** when a `MeterRegistry` is already in the app. Without it, `IdempotentService` uses `IdempotentMetrics.NOOP`.
+
 ## Configuration
 
 | Property | Default | Description |

--- a/idempotent-micrometer/README.md
+++ b/idempotent-micrometer/README.md
@@ -1,0 +1,50 @@
+<div align="center">
+
+# idempotent-micrometer
+
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.arun0009/idempotent-micrometer?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.arun0009/idempotent-micrometer)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Java](https://img.shields.io/badge/Java-17%2B-blue.svg)](https://adoptium.net)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.x-brightgreen.svg)](https://spring.io/projects/spring-boot)
+
+</div>
+
+**Micrometer meters for every idempotent execution.** Optional module: add it when you already have a `MeterRegistry`; leave it off and `IdempotentService` uses a no-op.
+
+## Install
+
+```xml
+<dependency>
+	<groupId>io.github.arun0009</groupId>
+	<artifactId>idempotent-micrometer</artifactId>
+	<version>${idempotent.version}</version>
+</dependency>
+```
+
+No extra properties. If a `MeterRegistry` bean is present, auto-config wires `MicrometerIdempotentMetrics`. If it is absent, core falls back to `IdempotentMetrics.NOOP`.
+
+## Meters
+
+| Meter | Type | Tags |
+|-------|------|------|
+| `idempotent.executions` | Counter | `process`, `outcome` — `hit`, `hit_after_wait`, `new_success`, `new_failure`, `wait_exhausted` |
+| `idempotent.operations` | Timer | `process`, `outcome` — `success`, `failure` |
+| `idempotent.conflicts` | Counter | `process` |
+
+Each `execute()` increments `idempotent.executions` once with its **terminal** outcome. The timer is recorded only when the operation actually ran (`NEW_SUCCESS` / `NEW_FAILURE`). A lost insert race increments `idempotent.conflicts` separately, then the request still records one terminal outcome (usually `hit` or `hit_after_wait`).
+
+| Outcome | Meaning |
+|---------|---------|
+| `hit` | Completed entry already in the store |
+| `hit_after_wait` | Waited for another caller, then returned their result |
+| `new_success` | This caller ran the operation and cached it |
+| `new_failure` | Operation threw, or returned a non-2xx `ResponseEntity` (not cached) |
+| `wait_exhausted` | In-progress wait budget ran out |
+
+`process` is the method's declaring type plus name, for example `__PaymentController.pay()`.
+
+## Custom `IdempotentMetrics`
+
+The SPI lives in `idempotent-core`. A user `IdempotentMetrics` bean replaces the Micrometer implementation (and the no-op) — it does not run alongside it.
+
+Back to the [project overview](../README.md).


### PR DESCRIPTION
## Summary

- Add `idempotent-micrometer/README.md` (install, meters, outcomes, custom SPI replaces Micrometer)
- Link it from the root Metrics section and a short pointer in `idempotent-core`

Follow-up to #141: every other module already had a README.

## Test plan

- [ ] Check links from [README.md](README.md) and [idempotent-core/README.md](idempotent-core/README.md) on GitHub
- [ ] Skim meter names/tags against `MicrometerIdempotentMetrics`

Made with [Cursor](https://cursor.com)