### PR TITLE
Add support for key ownership with attributes

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -36,6 +36,13 @@ This release contains intentional breaking changes to simplify configuration and
 #### RDS storage schema
 
 - Column `expiration_time_millis` renamed to `expires_at` (BIGINT, epoch milliseconds). Recreate or migrate your table before upgrading.
+- Column `attributes` stores claim attributes as serialized JSON. Add it to existing tables before enabling `IdempotentKeyAuthorization`:
+
+```sql
+ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT;
+```
+
+- Use `MEDIUMTEXT` for `attributes` on MySQL/MariaDB. Existing rows may remain `NULL` and are treated as having no attributes.
 
 #### Jackson customizer interfaces
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -42,7 +42,7 @@ This release contains intentional breaking changes to simplify configuration and
 ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT;
 ```
 
-- Use `MEDIUMTEXT` for `attributes` on MySQL/MariaDB. Existing rows may remain `NULL` and are treated as having no attributes.
+- On MySQL use `MEDIUMTEXT` for `attributes` and drop `IF NOT EXISTS`, which MySQL does not support on `ADD COLUMN` (MariaDB does). Existing rows may remain `NULL` and are treated as having no attributes.
 
 #### Jackson customizer interfaces
 

--- a/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/IdempotentCoreAutoConfiguration.java
+++ b/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/IdempotentCoreAutoConfiguration.java
@@ -31,14 +31,27 @@ class IdempotentCoreAutoConfiguration {
         return IdempotentMetrics.NOOP;
     }
 
+    /**
+     * Key ownership is opt-in: without a user-supplied {@link IdempotentKeyAuthorization} bean, no
+     * attributes are recorded and every caller may use any key.
+     */
+    @Bean
+    @ConditionalOnMissingBean(IdempotentKeyAuthorization.class)
+    IdempotentKeyAuthorization idempotentKeyGuard() {
+        return IdempotentKeyAuthorization.NOOP;
+    }
+
     @Bean
     @ConditionalOnMissingBean(IdempotentService.class)
     IdempotentService idempotentService(
-            IdempotentStore idempotentStore, IdempotentProperties properties, IdempotentMetrics metrics) {
+            IdempotentStore idempotentStore,
+            IdempotentProperties properties,
+            IdempotentMetrics metrics,
+            IdempotentKeyAuthorization keyGuard) {
         var inprogress = properties.inprogress();
         var waitStrategy = new WaitStrategy(
                 inprogress.maxRetries(), inprogress.retryInitialInterval(), inprogress.retryMultiplier());
-        return new IdempotentService(idempotentStore, waitStrategy, metrics);
+        return new IdempotentService(idempotentStore, waitStrategy, metrics, keyGuard);
     }
 
     /**

--- a/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/IdempotentKeyAuthorization.java
+++ b/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/IdempotentKeyAuthorization.java
@@ -1,0 +1,53 @@
+package io.github.arun0009.idempotent.core;
+
+import io.github.arun0009.idempotent.core.persistence.IdempotentStore.IdempotentKey;
+
+import java.util.Map;
+
+/**
+ * Controls access to idempotency keys based on the caller that claimed them.
+ *
+ * <p>{@link #getClaimAttributes(IdempotentKey)} captures attributes when a key is claimed.
+ * {@link #authorize(IdempotentKey, Map)} checks access whenever an existing entry is read.
+ * Throw from {@code ensure} to reject the caller.
+ *
+ * <p>Implementations obtain caller identity from their own context. The guard is optional;
+ * core uses {@link #NOOP} when none is configured.
+ *
+ * <p>Implementations must be thread-safe.
+ */
+public interface IdempotentKeyAuthorization {
+
+    /**
+     * Returns attributes to store with a newly claimed entry.
+     *
+     * @param key the idempotent key being claimed
+     * @return attributes to store, or an empty map
+     */
+    Map<String, String> getClaimAttributes(IdempotentKey key);
+
+    /**
+     * Checks whether the current caller may use an existing entry.
+     *
+     * @param key              the idempotent key being read
+     * @param storedAttributes attributes recorded when the entry was claimed
+     * @throws RuntimeException if access is denied
+     */
+    void authorize(IdempotentKey key, Map<String, String> storedAttributes);
+
+    IdempotentKeyAuthorization NOOP = new Noop();
+
+    final class Noop implements IdempotentKeyAuthorization {
+        private Noop() {}
+
+        @Override
+        public Map<String, String> getClaimAttributes(IdempotentKey key) {
+            return Map.of();
+        }
+
+        @Override
+        public void authorize(IdempotentKey key, Map<String, String> storedAttributes) {
+            // noop
+        }
+    }
+}

--- a/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/persistence/IdempotentStore.java
+++ b/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/persistence/IdempotentStore.java
@@ -6,6 +6,7 @@ import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * Persistence contract for idempotent entries.
@@ -100,12 +101,27 @@ public interface IdempotentStore {
     /**
      * Stored value.
      *
-     * @param status    current status of the operation
-     * @param expiresAt absolute expiry instant
-     * @param response  cached response, or {@code null} when no response has been recorded yet
-     *                  (typically while {@link Status#IN_PROGRESS}) or when the response is null
+     * @param status     current status of the operation
+     * @param expiresAt  absolute expiry instant
+     * @param response   cached response, or {@code null} when no response has been recorded yet
+     *                   (typically while {@link Status#IN_PROGRESS}) or when the response is null
+     * @param attributes attributes captured when the key was claimed.
      */
-    record Value(Status status, Instant expiresAt, @Nullable Object response) implements Serializable {}
+    record Value(Status status, Instant expiresAt, @Nullable Object response, Map<String, String> attributes)
+            implements Serializable {
+
+        public Value(
+                Status status, Instant expiresAt, @Nullable Object response, @Nullable Map<String, String> attributes) {
+            this.status = status;
+            this.expiresAt = expiresAt;
+            this.response = response;
+            this.attributes = attributes == null ? Map.of() : Map.copyOf(attributes);
+        }
+
+        public Value(Status status, Instant expiresAt, @Nullable Object response) {
+            this(status, expiresAt, response, Map.of());
+        }
+    }
 
     /** Lifecycle status of an idempotent entry. */
     enum Status {

--- a/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/service/IdempotentService.java
+++ b/idempotent-core/src/main/java/io/github/arun0009/idempotent/core/service/IdempotentService.java
@@ -1,5 +1,6 @@
 package io.github.arun0009.idempotent.core.service;
 
+import io.github.arun0009.idempotent.core.IdempotentKeyAuthorization;
 import io.github.arun0009.idempotent.core.exception.IdempotentException;
 import io.github.arun0009.idempotent.core.exception.IdempotentKeyConflictException;
 import io.github.arun0009.idempotent.core.exception.IdempotentWaitExhaustedException;
@@ -15,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -34,6 +36,11 @@ import static io.github.arun0009.idempotent.core.persistence.IdempotentStore.Sta
  * <h2>Exception propagation</h2>
  * Domain exceptions thrown by the operation propagate to the caller as-is (no wrapping in
  * {@link IdempotentException}). Cleanup of the in-progress entry happens before the throw.
+ *
+ * <h2>Key ownership</h2>
+ * An optional {@link IdempotentKeyAuthorization} binds each key to whoever claimed it. Its attributes are
+ * captured when the key is claimed and verified on every read of an existing entry, before a cached
+ * response is returned and before any in-progress wait. Defaults to {@link IdempotentKeyAuthorization#NOOP}.
  */
 public class IdempotentService {
 
@@ -42,6 +49,7 @@ public class IdempotentService {
     private final IdempotentStore idempotentStore;
     private final IdempotentCompletionAwaiter completionAwaiter;
     private final IdempotentMetrics metrics;
+    private final IdempotentKeyAuthorization keyGuard;
 
     public IdempotentService(IdempotentStore idempotentStore) {
         this(idempotentStore, WaitStrategy.withDefaults(), IdempotentMetrics.NOOP);
@@ -52,9 +60,18 @@ public class IdempotentService {
     }
 
     public IdempotentService(IdempotentStore idempotentStore, WaitStrategy waitStrategy, IdempotentMetrics metrics) {
+        this(idempotentStore, waitStrategy, metrics, IdempotentKeyAuthorization.NOOP);
+    }
+
+    public IdempotentService(
+            IdempotentStore idempotentStore,
+            WaitStrategy waitStrategy,
+            IdempotentMetrics metrics,
+            IdempotentKeyAuthorization keyGuard) {
         this.idempotentStore = idempotentStore;
         this.completionAwaiter = new IdempotentCompletionAwaiter(idempotentStore, waitStrategy);
         this.metrics = metrics;
+        this.keyGuard = keyGuard;
     }
 
     // ---- Untyped Supplier-based overloads (use Object.class internally) -----------------------
@@ -128,6 +145,8 @@ public class IdempotentService {
     }
 
     private @Nullable Object handleExisting(IdempotentStore.IdempotentKey idempotentKey, IdempotentStore.Value value) {
+        // Fail fast before waiting
+        keyGuard.authorize(idempotentKey, value.attributes());
         if (value.status() == COMPLETED) {
             metrics.record(idempotentKey.processName(), Outcome.HIT, null);
             return value.response();
@@ -150,8 +169,9 @@ public class IdempotentService {
             Duration ttl)
             throws Throwable {
         var expiresAt = Instant.now().plus(ttl);
+        var attributes = keyGuard.getClaimAttributes(idempotentKey);
         try {
-            idempotentStore.store(idempotentKey, new IdempotentStore.Value(IN_PROGRESS, expiresAt, null));
+            idempotentStore.store(idempotentKey, new IdempotentStore.Value(IN_PROGRESS, expiresAt, null, attributes));
         } catch (IdempotentKeyConflictException e) {
             log.info("Idempotent key conflict for {}; following existing-entry path", idempotentKey.key());
             metrics.recordConflict(idempotentKey.processName());
@@ -169,7 +189,7 @@ public class IdempotentService {
         try {
             T result = operation.execute();
             var elapsed = Duration.ofNanos(System.nanoTime() - startNanos);
-            var successful = updateStoreWithResponse(idempotentKey, result, expiresAt);
+            var successful = updateStoreWithResponse(idempotentKey, result, expiresAt, attributes);
             var outcome = successful ? Outcome.NEW_SUCCESS : Outcome.NEW_FAILURE;
             metrics.record(idempotentKey.processName(), outcome, elapsed);
             return result;
@@ -182,7 +202,10 @@ public class IdempotentService {
     }
 
     private boolean updateStoreWithResponse(
-            IdempotentStore.IdempotentKey idempotentKey, @Nullable Object response, Instant expiresAt) {
+            IdempotentStore.IdempotentKey idempotentKey,
+            @Nullable Object response,
+            Instant expiresAt,
+            Map<String, String> attributes) {
         if (response instanceof ResponseEntity<?> re && !re.getStatusCode().is2xxSuccessful()) {
             // Non-2xx responses are treated as failures and not cached so the caller can retry.
             idempotentStore.remove(idempotentKey);
@@ -190,7 +213,7 @@ public class IdempotentService {
         }
         // Cache the result — including null (void methods or intentional null returns) so
         // later calls with the same key short-circuit instead of re-executing.
-        idempotentStore.update(idempotentKey, new IdempotentStore.Value(COMPLETED, expiresAt, response));
+        idempotentStore.update(idempotentKey, new IdempotentStore.Value(COMPLETED, expiresAt, response, attributes));
         return true;
     }
 }

--- a/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/serialization/JacksonIdempotentPayloadCodecTest.java
+++ b/idempotent-core/src/test/java/io/github/arun0009/idempotent/core/serialization/JacksonIdempotentPayloadCodecTest.java
@@ -1,5 +1,6 @@
 package io.github.arun0009.idempotent.core.serialization;
 
+import io.github.arun0009.idempotent.core.persistence.IdempotentStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
@@ -7,7 +8,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import java.io.Serializable;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -116,6 +119,46 @@ class JacksonIdempotentPayloadCodecTest {
         assertEquals(204, re.getStatusCode().value());
         assertNull(re.getBody());
         assertEquals(List.of("1"), re.getHeaders().get("X-Count"));
+    }
+
+    @Test
+    void valueWithAttributesRoundTrips() {
+        var original = new IdempotentStore.Value(
+                IdempotentStore.Status.COMPLETED,
+                Instant.parse("2026-01-01T00:00:00Z"),
+                "body",
+                Map.of("owner", "user-1"));
+
+        var deserialized = codec.deserializeFromBytes(codec.serializeToBytes(original), IdempotentStore.Value.class);
+
+        assertEquals(IdempotentStore.Status.COMPLETED, deserialized.status());
+        assertEquals(Instant.parse("2026-01-01T00:00:00Z"), deserialized.expiresAt());
+        assertEquals("body", deserialized.response());
+        assertEquals(Map.of("owner", "user-1"), deserialized.attributes());
+    }
+
+    @Test
+    void valueWithoutAttributesFieldDeserializesToEmptyMap() {
+        // Entries persisted before `attributes` existed have no such field.
+        // language=JSON
+        var legacyJson = """
+                {
+                  "@class": "io.github.arun0009.idempotent.core.persistence.IdempotentStore$Value",
+                  "status": [
+                    "io.github.arun0009.idempotent.core.persistence.IdempotentStore$Status",
+                    "COMPLETED"
+                  ],
+                  "expiresAt": [
+                    "java.time.Instant",
+                    "2026-01-01T00:00:00Z"
+                  ],
+                  "response": "body"
+                }""";
+
+        var deserialized = codec.deserializeFromBytes(legacyJson.getBytes(), IdempotentStore.Value.class);
+        assertEquals(IdempotentStore.Status.COMPLETED, deserialized.status());
+        assertEquals("body", deserialized.response());
+        assertEquals(Map.of(), deserialized.attributes());
     }
 
     @Test

--- a/idempotent-dynamo/src/main/java/io/github/arun0009/idempotent/dynamo/DynamoIdempotentStore.java
+++ b/idempotent-dynamo/src/main/java/io/github/arun0009/idempotent/dynamo/DynamoIdempotentStore.java
@@ -64,6 +64,7 @@ public class DynamoIdempotentStore implements IdempotentStore {
                 .sortValue(idempotentKey.processName())
                 .build();
         var idempotentItem = getTable().getItem(dynamoKey);
+        //noinspection ConstantValue
         if (idempotentItem == null) {
             return null;
         }

--- a/idempotent-rds/README.md
+++ b/idempotent-rds/README.md
@@ -40,13 +40,24 @@ CREATE TABLE idempotent (
 	status       VARCHAR(50)  NOT NULL,
 	expires_at   BIGINT       NOT NULL,
 	response     TEXT,
+	attributes   TEXT,
 	PRIMARY KEY (key_id, process_name)
 );
 
 CREATE INDEX idx_idempotent_expires_at ON idempotent (expires_at);
 ```
 
-On MySQL/MariaDB use `MEDIUMTEXT` for `response` (`TEXT` is 64KB).
+On MySQL/MariaDB use `MEDIUMTEXT` for `response` and `attributes` (`TEXT` is 64KB).
+
+For an existing table, add the authorization column before enabling key authorization:
+
+```sql
+ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT;
+```
+
+Use `MEDIUMTEXT` instead of `TEXT` on MySQL/MariaDB. When `initialize-schema` is enabled, the
+initializer creates the column and applies this migration automatically; production deployments
+should preferably run it through Flyway, Liquibase, or the normal database migration process.
 
 `expires_at` is epoch **milliseconds**. The composite primary key serves point lookups; the `expires_at` index serves the cleanup task. Unrecognized dialects fall back to a generic implementation with a startup warning.
 

--- a/idempotent-rds/README.md
+++ b/idempotent-rds/README.md
@@ -55,8 +55,8 @@ For an existing table, add the authorization column before enabling key authoriz
 ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT;
 ```
 
-Use `MEDIUMTEXT` instead of `TEXT` on MySQL/MariaDB. When `initialize-schema` is enabled, the
-initializer creates the column and applies this migration automatically; production deployments
+Use `MEDIUMTEXT` instead of `TEXT` on MySQL/MariaDB, and drop `IF NOT EXISTS` on MySQL, which does not support it on `ADD COLUMN` (MariaDB does). 
+When `initialize-schema` is enabled, the initializer creates the column and applies this migration automatically; production deployments
 should preferably run it through Flyway, Liquibase, or the normal database migration process.
 
 `expires_at` is epoch **milliseconds**. The composite primary key serves point lookups; the `expires_at` index serves the cleanup task. Unrecognized dialects fall back to a generic implementation with a startup warning.

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsIdempotentStore.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsIdempotentStore.java
@@ -11,6 +11,7 @@ import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.time.Instant;
+import java.util.Map;
 
 /**
  * RDS idempotent store using JdbcTemplate with atomic race condition protection.
@@ -30,7 +31,7 @@ public class RdsIdempotentStore implements IdempotentStore {
     @Override
     public @Nullable Value loadValue(IdempotentKey key, Class<?> returnType) {
         var sql = """
-                SELECT status, expires_at, response FROM %s WHERE key_id = ? AND process_name = ?
+                SELECT status, expires_at, response, attributes FROM %s WHERE key_id = ? AND process_name = ?
                 """.formatted(tableName);
         try {
             var value = jdbcTemplate.queryForObject(
@@ -40,7 +41,8 @@ public class RdsIdempotentStore implements IdempotentStore {
                         Instant expiresAt = Instant.ofEpochMilli(rs.getLong("expires_at"));
                         String serializedResponse = rs.getString("response");
                         Object response = payloadCodec.deserializeFromString(serializedResponse, returnType);
-                        return new Value(status, expiresAt, response);
+                        Map<String, String> attributes = deserializeAttributes(rs.getString("attributes"));
+                        return new Value(status, expiresAt, response, attributes);
                     },
                     key.key(),
                     key.processName());
@@ -50,13 +52,23 @@ public class RdsIdempotentStore implements IdempotentStore {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, String> deserializeAttributes(@Nullable String serializedAttributes) {
+        if (serializedAttributes == null) {
+            return Map.of();
+        }
+        var attributes = payloadCodec.deserializeFromString(serializedAttributes, Map.class);
+        return attributes == null ? Map.of() : (Map<String, String>) attributes;
+    }
+
     @Override
     public void store(IdempotentKey key, Value value) {
         try {
             var serializedResponse = payloadCodec.serializeToString(value.response());
+            var serializedAttributes = payloadCodec.serializeToString(value.attributes());
             var sql = """
-                    INSERT INTO %s (key_id, process_name, status, expires_at, response)
-                    VALUES (?, ?, ?, ?, ?)
+                    INSERT INTO %s (key_id, process_name, status, expires_at, response, attributes)
+                    VALUES (?, ?, ?, ?, ?, ?)
                     """.formatted(tableName);
             jdbcTemplate.update(
                     sql,
@@ -64,7 +76,8 @@ public class RdsIdempotentStore implements IdempotentStore {
                     key.processName(),
                     value.status().name(),
                     value.expiresAt().toEpochMilli(),
-                    serializedResponse);
+                    serializedResponse,
+                    serializedAttributes);
         } catch (IdempotentPayloadCodecException e) {
             throw new IdempotentException("Error serializing value response", e);
         } catch (DuplicateKeyException e) {
@@ -84,8 +97,9 @@ public class RdsIdempotentStore implements IdempotentStore {
     public void update(IdempotentKey key, Value value) {
         try {
             var serializedResponse = payloadCodec.serializeToString(value.response());
+            var serializedAttributes = payloadCodec.serializeToString(value.attributes());
             var sql = """
-                    UPDATE %s SET status = ?, expires_at = ?, response = ?
+                    UPDATE %s SET status = ?, expires_at = ?, response = ?, attributes = ?
                     WHERE key_id = ? AND process_name = ?
                     """.formatted(tableName);
             jdbcTemplate.update(
@@ -93,6 +107,7 @@ public class RdsIdempotentStore implements IdempotentStore {
                     value.status().name(),
                     value.expiresAt().toEpochMilli(),
                     serializedResponse,
+                    serializedAttributes,
                     key.key(),
                     key.processName());
         } catch (IdempotentPayloadCodecException e) {

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
@@ -40,6 +40,7 @@ public class RdsSchemaInitializer implements InitializingBean {
             return;
         }
         create(dialect);
+        migrateAttributes(dialect);
     }
 
     private boolean shouldCreate() {
@@ -61,6 +62,18 @@ public class RdsSchemaInitializer implements InitializingBean {
                 }
                 log.debug("Idempotent table '{}' already exists", tableName, e);
             }
+        }
+    }
+
+    private void migrateAttributes(RdsDialect dialect) {
+        try {
+            jdbcTemplate.execute(RdsSchemaStatements.addAttributesColumn(dialect, tableName));
+        } catch (BadSqlGrammarException e) {
+            // Existing installations may manage schema changes outside this initializer.
+            log.warn(
+                    "Could not add attributes column to idempotent table '{}'; apply the migration manually",
+                    tableName,
+                    e);
         }
     }
 

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializer.java
@@ -66,6 +66,9 @@ public class RdsSchemaInitializer implements InitializingBean {
     }
 
     private void migrateAttributes(RdsDialect dialect) {
+        if (existsColAttributes()) {
+            return;
+        }
         try {
             jdbcTemplate.execute(RdsSchemaStatements.addAttributesColumn(dialect, tableName));
         } catch (BadSqlGrammarException e) {
@@ -80,6 +83,15 @@ public class RdsSchemaInitializer implements InitializingBean {
     private boolean tableExists() {
         try {
             jdbcTemplate.execute("SELECT 1 FROM %s WHERE 1 = 0".formatted(tableName));
+            return true;
+        } catch (BadSqlGrammarException e) {
+            return false;
+        }
+    }
+
+    private boolean existsColAttributes() {
+        try {
+            jdbcTemplate.execute("SELECT attributes FROM %s WHERE 1 = 0".formatted(tableName));
             return true;
         } catch (BadSqlGrammarException e) {
             return false;

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
@@ -44,7 +44,8 @@ final class RdsSchemaStatements {
 
     static String addAttributesColumn(RdsDialect dialect, String tableName) {
         return switch (dialect) {
-            case MYSQL -> "ALTER TABLE %s ADD COLUMN IF NOT EXISTS attributes MEDIUMTEXT".formatted(tableName);
+            // MySQL has no ADD COLUMN IF NOT EXISTS; callers check for the column first.
+            case MYSQL -> "ALTER TABLE %s ADD COLUMN attributes MEDIUMTEXT".formatted(tableName);
             case POSTGRES, H2 -> "ALTER TABLE %s ADD COLUMN IF NOT EXISTS attributes TEXT".formatted(tableName);
             case GENERIC -> throw new IllegalArgumentException("No migration for unrecognized database: " + tableName);
         };

--- a/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
+++ b/idempotent-rds/src/main/java/io/github/arun0009/idempotent/rds/RdsSchemaStatements.java
@@ -21,6 +21,7 @@ final class RdsSchemaStatements {
                         status VARCHAR(50) NOT NULL,
                         expires_at BIGINT NOT NULL,
                         response MEDIUMTEXT,
+                        attributes MEDIUMTEXT,
                         PRIMARY KEY (key_id, process_name),
                         KEY %s (expires_at)
                     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4""".formatted(tableName, indexName));
@@ -33,10 +34,19 @@ final class RdsSchemaStatements {
                             status VARCHAR(50) NOT NULL,
                             expires_at BIGINT NOT NULL,
                             response TEXT,
+                            attributes TEXT,
                             PRIMARY KEY (key_id, process_name)
                         )""".formatted(tableName),
                         "CREATE INDEX IF NOT EXISTS %s ON %s (expires_at)".formatted(indexName, tableName));
             case GENERIC -> throw new IllegalArgumentException("No DDL for unrecognized database: " + tableName);
+        };
+    }
+
+    static String addAttributesColumn(RdsDialect dialect, String tableName) {
+        return switch (dialect) {
+            case MYSQL -> "ALTER TABLE %s ADD COLUMN IF NOT EXISTS attributes MEDIUMTEXT".formatted(tableName);
+            case POSTGRES, H2 -> "ALTER TABLE %s ADD COLUMN IF NOT EXISTS attributes TEXT".formatted(tableName);
+            case GENERIC -> throw new IllegalArgumentException("No migration for unrecognized database: " + tableName);
         };
     }
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreH2Test.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreH2Test.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import javax.sql.DataSource;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -102,6 +103,18 @@ class RdsIdempotentStoreH2Test {
         assertNotNull(retrieved);
         assertEquals(Status.COMPLETED, retrieved.status());
         assertEquals("success", retrieved.response());
+    }
+
+    @Test
+    void testAttributesRoundTrip() {
+        IdempotentKey key = new IdempotentKey("attributes-key", "test-process");
+        Value value = new Value(Status.COMPLETED, Instant.now().plusMillis(5000), "success", Map.of("owner", "user-1"));
+
+        idempotentStore.store(key, value);
+
+        var retrieved = idempotentStore.getValue(key, String.class);
+        assertNotNull(retrieved);
+        assertEquals(Map.of("owner", "user-1"), retrieved.attributes());
     }
 
     @Test

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreMySQLTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsIdempotentStoreMySQLTest.java
@@ -9,11 +9,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.sql.init.DatabaseInitializationMode;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import javax.sql.DataSource;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +38,9 @@ class RdsIdempotentStoreMySQLTest {
 
     @Autowired
     private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private DataSource dataSource;
 
     @BeforeEach
     void setUp() {
@@ -136,6 +141,26 @@ class RdsIdempotentStoreMySQLTest {
         assertEquals(123, response.get("id"));
         assertEquals("active", response.get("status"));
         assertEquals(List.of("tag1", "tag2"), response.get("tags"));
+    }
+
+    @Test
+    void testAttributesMigrationOnLegacyTable() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS legacy_idempotent");
+        jdbcTemplate.execute("""
+                CREATE TABLE legacy_idempotent (
+                    key_id VARCHAR(255) NOT NULL,
+                    process_name VARCHAR(255) NOT NULL,
+                    status VARCHAR(50) NOT NULL,
+                    expires_at BIGINT NOT NULL,
+                    response MEDIUMTEXT,
+                    PRIMARY KEY (key_id, process_name)
+                ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4""");
+
+        new RdsSchemaInitializer(dataSource, jdbcTemplate, "legacy_idempotent", DatabaseInitializationMode.ALWAYS)
+                .afterPropertiesSet();
+
+        jdbcTemplate.execute("SELECT attributes FROM legacy_idempotent WHERE 1 = 0");
+        jdbcTemplate.execute("DROP TABLE legacy_idempotent");
     }
 
     @Test

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializerTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaInitializerTest.java
@@ -78,6 +78,33 @@ class RdsSchemaInitializerTest {
     }
 
     @Test
+    void addsAttributesColumnToLegacyTable() {
+        jdbcTemplate.execute("""
+                CREATE TABLE idempotent (
+                    key_id VARCHAR(255) NOT NULL,
+                    process_name VARCHAR(255) NOT NULL,
+                    status VARCHAR(50) NOT NULL,
+                    expires_at BIGINT NOT NULL,
+                    response TEXT,
+                    PRIMARY KEY (key_id, process_name)
+                )""");
+
+        initializer("idempotent", DatabaseInitializationMode.ALWAYS).afterPropertiesSet();
+
+        assertDoesNotThrow(() -> jdbcTemplate.execute("SELECT attributes FROM idempotent WHERE 1 = 0"));
+    }
+
+    @Test
+    void skipsAttributesMigrationWhenColumnExists() {
+        initializer("idempotent", DatabaseInitializationMode.ALWAYS).afterPropertiesSet();
+        var spy = Mockito.spy(jdbcTemplate);
+
+        new RdsSchemaInitializer(dataSource, spy, "idempotent", DatabaseInitializationMode.ALWAYS).afterPropertiesSet();
+
+        Mockito.verify(spy, never()).execute(startsWith("ALTER TABLE"));
+    }
+
+    @Test
     void doesNothingWhenNever() {
         initializer("idempotent", DatabaseInitializationMode.NEVER).afterPropertiesSet();
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
@@ -26,6 +26,16 @@ class RdsSchemaStatementsTest {
                         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"""), RdsSchemaStatements.ddl(RdsDialect.MYSQL, "idempotent"));
     }
 
+    @Test
+    void rendersAttributesMigration() {
+        assertEquals(
+                "ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT",
+                RdsSchemaStatements.addAttributesColumn(RdsDialect.POSTGRES, "idempotent"));
+        assertEquals(
+                "ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes MEDIUMTEXT",
+                RdsSchemaStatements.addAttributesColumn(RdsDialect.MYSQL, "idempotent"));
+    }
+
     @ParameterizedTest
     @EnumSource(
             value = RdsDialect.class,

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
@@ -33,7 +33,7 @@ class RdsSchemaStatementsTest {
                 "ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes TEXT",
                 RdsSchemaStatements.addAttributesColumn(RdsDialect.POSTGRES, "idempotent"));
         assertEquals(
-                "ALTER TABLE idempotent ADD COLUMN IF NOT EXISTS attributes MEDIUMTEXT",
+                "ALTER TABLE idempotent ADD COLUMN attributes MEDIUMTEXT",
                 RdsSchemaStatements.addAttributesColumn(RdsDialect.MYSQL, "idempotent"));
     }
 

--- a/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
+++ b/idempotent-rds/src/test/java/io/github/arun0009/idempotent/rds/RdsSchemaStatementsTest.java
@@ -21,6 +21,7 @@ class RdsSchemaStatementsTest {
                             status VARCHAR(50) NOT NULL,
                             expires_at BIGINT NOT NULL,
                             response MEDIUMTEXT,
+                            attributes MEDIUMTEXT,
                             PRIMARY KEY (key_id, process_name),
                             KEY idx_idempotent_expires_at (expires_at)
                         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4"""), RdsSchemaStatements.ddl(RdsDialect.MYSQL, "idempotent"));
@@ -49,6 +50,7 @@ class RdsSchemaStatementsTest {
                             status VARCHAR(50) NOT NULL,
                             expires_at BIGINT NOT NULL,
                             response TEXT,
+                            attributes TEXT,
                             PRIMARY KEY (key_id, process_name)
                         )""", "CREATE INDEX IF NOT EXISTS idx_idempotent_expires_at ON idempotent (expires_at)"),
                 RdsSchemaStatements.ddl(dialect, "idempotent"));


### PR DESCRIPTION
Added idempotency-key authorization to prevent one user from receiving a response cached by another user.
Previously, if User 1 and User 2 used the same idempotency key, User 2 could receive User 1’s stored response. The new authorization hook stores caller attributes when the key is claimed and validates them whenever the existing entry is accessed.
This allows applications to reject unauthorized key reuse while keeping caller identity handling outside the core module. The authorization feature is optional and uses a no-op implementation by default.